### PR TITLE
fix(dataSource): fix datasource with empty config did not return promise

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-preview-vue",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/src/lowcode/dataSource.js
+++ b/src/lowcode/dataSource.js
@@ -32,11 +32,11 @@ const globalWillFetch = dataSources.willFetch ? createFn(dataSources.willFetch.v
 const load = (http, options, dataSource, shouldFetch) => (params, customUrl) => {
   // 如果没有配置远程请求，则直接返回静态数据，返回前可能会有全局数据处理
   if (!options) {
-    return globalDataHandle(dataSource.config.data)
+    return Promise.resolve(globalDataHandle(dataSource.config.data))
   }
 
   if (!shouldFetch()) {
-    return
+    return Promise.resolve()
   }
 
   dataSource.status = 'loading'


### PR DESCRIPTION
PR Type

- [x] BugFix

What is the current behavior?

this.dataSourceMap.xxx.load() did not return an promise when config is empty

What is the new behavior?

return promise